### PR TITLE
Merge stackblitz branch to main

### DIFF
--- a/.github/workflows/merge-stackblitz-to-main.yml
+++ b/.github/workflows/merge-stackblitz-to-main.yml
@@ -48,7 +48,7 @@ jobs:
           git push origin stackblitz-pr
 
       - name: Create pull request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.REPOSITORY_TOKEN }}
           script: |

--- a/.github/workflows/stackblitz-fetch-main.yml
+++ b/.github/workflows/stackblitz-fetch-main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 检出代码
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true


### PR DESCRIPTION
该 PR 由 GitHub Actions 自动创建，用于合并 stackblitz 分支到 main 分支，请检查是否正确。